### PR TITLE
Update company-arduino paths for v1.8.6

### DIFF
--- a/company-arduino.el
+++ b/company-arduino.el
@@ -99,13 +99,12 @@ wherever you want to develop Arduino application.")
 (defvar company-arduino-home (file-truename (or (getenv "ARDUINO_HOME") ""))
   "Installed directory of Arduino IDE.  Default value is $ARDUINO_HOME.")
 
-(defvar company-arduino-header (format "%s%s" company-arduino-home "/hardware/arduino/avr/cores/arduino/Arduino.h")
+(defvar company-arduino-header (format "%s%s" company-arduino-home "/cores/arduino/Arduino.h")
   "Place of Arduino.h, which Arduino IDE includes by default.")
 
 (defvar company-arduino-includes-dirs
-  (cl-loop with dirs = '("/hardware/arduino/avr/cores/arduino/"
-                         "/hardware/tools/avr/include/"
-                         "/hardware/arduino/avr/libraries/")
+  (cl-loop with dirs = '("/cores/arduino/"
+                         "/libraries/")
            for include-dir in dirs
            collect (format "%s%s" company-arduino-home include-dir) into include-dirs
            finally return include-dirs)

--- a/company-arduino.el
+++ b/company-arduino.el
@@ -102,12 +102,14 @@ wherever you want to develop Arduino application.")
 (defvar company-arduino-header (format "%s%s" company-arduino-home "/cores/arduino/Arduino.h")
   "Place of Arduino.h, which Arduino IDE includes by default.")
 
+(defvar company-arduino-avr-gcc-headers (file-truename (or (getenv "ARDUINO_AVR_GCC_HEADERS") "")))
+
 (defvar company-arduino-includes-dirs
-  (cl-loop with dirs = '("/cores/arduino/"
+  (append (cl-loop with dirs = '("/cores/arduino/"
                          "/libraries/")
            for include-dir in dirs
            collect (format "%s%s" company-arduino-home include-dir) into include-dirs
-           finally return include-dirs)
+           finally return include-dirs) company-arduino-avr-gcc-headers)
   "Arduino's specific include directories.")
 
 (defvar irony-arduino-includes-options


### PR DESCRIPTION
I have adjusted the paths to work for Arduino 1.8.6. I have also added a new environment variable to be used called `ARDUINO_AVR_GCC_HEADERS` which as the name implies it stores the location of the AVR GCC header files. This is because the path to this location is a bit harder to be figured out. It could be done with just the home path however I thought it would ultimately just be easy to add a path.

Here are where both of my environment variables are set to give a little bit of insight
```bash
$ echo $ARDUINO_AVR_GCC_HEADERS
/home/james/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/avr/include/
$ echo $ARDUINO_HOME
/home/james/.arduino15/packages/arduino/hardware/avr/1.8.6
```
These changes will likely only be reflected on *nix based systems and may need to revised for Windows however I don't use windows and don't have much intention of trying to figure it out, I just wanted this awesome package to work for my needs.

The README would need to be updated, I would be happy doing that however unless I see any movement on this PR it's likely not to get done.

Closes #6
Closes #5